### PR TITLE
empty error block shown when datapackage.json validate succeeds

### DIFF
--- a/views/tools/dp/validate.html
+++ b/views/tools/dp/validate.html
@@ -34,6 +34,7 @@ Data Package Validator - Tools
   </span>
 </h2>
 
+{% if not result.valid %}
 <ul>
 {% for error in result.errors %}
   <li>
@@ -51,6 +52,7 @@ Data Package Validator - Tools
 <pre>
 {{errorsAsJson}}
 </pre>
+{% endif %}
 
 {% endif %}
 </div>


### PR DESCRIPTION
When using the datapackage.json validation tool, given a successful validation, an empty error block is shown.

Actual result:
![screen shot 2015-01-23 at 8 21 00 pm](https://cloud.githubusercontent.com/assets/333766/5873784/6d72dee8-a33d-11e4-9045-76a33cd6efc4.png)

Expected result:
![screen shot 2015-01-23 at 8 23 29 pm](https://cloud.githubusercontent.com/assets/333766/5873808/c031f3ee-a33d-11e4-87d6-c5975164675d.png)

To reproduce, validate a known-to-be-valid datapackage.json.