### PR TITLE
move homepage truncation to filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,10 @@ app.configure(function(){
 var env = new nunjucks.Environment(new nunjucks.FileSystemLoader('views'));
 env.express(app);
 
+env.addFilter('truncateHomepage', function (str) {
+  return str.replace(/^https?:\/\//, '');
+});
+
 // middleware to add trailing slash
 app.use(function(req, res, next) {
   if(req.url.substr(-1) === '/' && req.url.length > 1) {

--- a/views/_snippets.html
+++ b/views/_snippets.html
@@ -51,7 +51,7 @@
         <a href="{{dataset.bugs.url}}" class="btn btn-small" target="_blank"><i class="icon-exclamation-sign icon-white"></i> Report an Issue</a>
         {% endif %}
       </div>
-      <div class="homepage truncate"><i class="icon-home"></i> <a href="{{dataset.homepage}}" title="Home Page">{{ dataset.homepage.replace('https://', '')}}</a></div>
+      <div class="homepage truncate"><i class="icon-home"></i> <a href="{{dataset.homepage}}" title="Home Page">{{dataset.homepage | truncateHomepage}}</a></div>
       <div class="license">
         <i class="icon-legal"></i> <a href="{{dataset.licenses[0].url}}" title="Available under the following License">{{dataset.licenses[0].name or dataset.licenses[0].id}}</a>
         <br />


### PR DESCRIPTION
* fix the issue with an error being raised by nunjucks'
replace when we try to replace 'https://' with '' in an
empty homepage string
* a [PR](https://github.com/mozilla/nunjucks/pull/321)
is pending to make nunjucks' replace more robust
