### PR TITLE
Updated FAQ page to Standards to follow

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -5,7 +5,7 @@
 Tutorials on how to publish data as data packages.
 
 * [Introduction][intro]
-* [FAQ][faq]
+* [Standards to follow][faq]
 * [Publishing Specific Types of Data][intro]
   * [Tabular Data][tabular]
   * [Geospatial Data (Geodata)][geodata]

--- a/doc/index.md
+++ b/doc/index.md
@@ -5,7 +5,7 @@
 Tutorials on how to publish data as data packages.
 
 * [Introduction][intro]
-* [Standards to follow][faq]
+* [Best practice patterns][faq]
 * [Publishing Specific Types of Data][intro]
   * [Tabular Data][tabular]
   * [Geospatial Data (Geodata)][geodata]

--- a/doc/publish-faq.md
+++ b/doc/publish-faq.md
@@ -1,6 +1,6 @@
-# Publishing Data Packages - Standards
+# Publishing Data Packages - Best practice patterns
 
-This page details the standards that should be followed when creating a data package. It addresses
+This page summarizes the best practice patterns that should be followed when creating a data package. It addresses
 * The Data Package name, 
 * The resource and data file names,
 * The descriptor `datapackage.json`,
@@ -8,7 +8,9 @@ This page details the standards that should be followed when creating a data pac
 * The README file,
 * Examples of well-structured packages. 
 
-## 1) Data Package Name
+Complete specifications are available at http://dataprotocols.org/data-packages.
+
+## Data Package Name
 
 The Data Package name is used in the `name` field of the `datapackage.json`.
 
@@ -41,7 +43,7 @@ For time series data:
 
 ---
 
-## 2) Resource and File Names
+## Resource and File Names
 
 Similar to Data Package Names:
 
@@ -61,7 +63,7 @@ or time series facets.
 
 ----
 
-## 3) Descriptor `datapackage.json`
+## Descriptor `datapackage.json`
 
 ### Alignment
 
@@ -97,13 +99,13 @@ Bad alignment:
 
 Please make sure to have your `datapackage.json` well structured to ease the understanding of your Data Package content. The [Online DataPackage.json Creator](http://data.okfn.org/tools/create) can help you create the general structure.  
 
-### Contributors and maintainers fields
+### Contributors fields
 
-Add the 'contributors' and 'maintainers' fields if you wish to keep the credits for the package.
+Add the 'contributors' field (original author of the package - see http://dataprotocols.org/data-packages) if you wish to keep the credits for the package.
 
 ----
 
-## 4) Data Package Folder Names and Structure
+## Data Package Folder Names and Structure
 
 It is standard practice to use the Data Package name (from the
 `datapackage.json`) for the name of the folder/directory in which the Data
@@ -116,7 +118,7 @@ If you include scripts allowing to automate the data extraction process, these s
 ----
 
 
-## 5) README
+## README
 
 A README is a text file giving (human-readable) information about your dataset.
 
@@ -174,15 +176,17 @@ Data Package in the License section.
 Since licensing information is often not clear from the data producers, the guideline here is to license the Data Package under the Public Domain Dedication and License, and then to add any relevant information or disclaimers regarding the source data. 
 
 See for example 
-* http://data.okfn.org/data/core/country-list#readme 
 * http://data.okfn.org/data/core/corruption-perceptions-index#readme
+* http://data.okfn.org/data/core/geo-nuts-administrative-boundaries#readme 
 
 See also the following thread https://discuss.okfn.org/t/copyright-on-data-sources/189.
 
 ----
 
-## 6) Examples
+## Examples
 
 For examples of well-structured Data Package see:
-* http://data.okfn.org/data/core/corruption-perceptions-index
+* For tabular data: http://data.okfn.org/data/core/corruption-perceptions-index
+* For geospatial data: http://data.okfn.org/data/core/geo-nuts-administrative-boundaries
+
 

--- a/doc/publish-faq.md
+++ b/doc/publish-faq.md
@@ -1,8 +1,16 @@
-# FAQs - Publishing Data Packages
+# Publishing Data Packages - Standards
 
-## Data Package Names
+This page details the standards that should be followed when creating a data package. It addresses
+* The Data Package name, 
+* The resource and data file names,
+* The descriptor `datapackage.json`,
+* The Data Package folder names and structure,
+* The README file,
+* Examples of well-structured packages. 
 
-Data Package names are used in the `name` field of the `datapackage.json`.
+## 1) Data Package Name
+
+The Data Package name is used in the `name` field of the `datapackage.json`.
 
 *This name is also frequently used for the folder/directory in which the Data
 Package is stored.*
@@ -33,7 +41,7 @@ For time series data:
 
 ---
 
-## Resource and File Names
+## 2) Resource and File Names
 
 Similar to Data Package Names:
 
@@ -53,8 +61,49 @@ or time series facets.
 
 ----
 
+## 3) Descriptor `datapackage.json`
 
-## Data Package Folder Names
+### Alignment
+
+With JSON, data is structured in a nested way through curly and squared brackets. Though the alignment of these structures is not relevant for computer programs, it makes it easier for the human reader if they are properly aligned.
+
+Good alignment:
+```
+{
+  "name": "corruption-perceptions-index",
+  "title": "Corruption Perceptions Index (CPI)",
+  "sources": [
+    {
+      "name": "Transparency International",
+      "web": "http://www.transparency.org/research/cpi/overview"
+    }
+  ],
+...
+}
+```
+
+Bad alignment:
+```
+{
+  "name": "corruption-perceptions-index","title": "Corruption Perceptions Index (CPI)",
+  "sources": 
+  [{
+    "name": "Transparency International",
+    "web": "http://www.transparency.org/research/cpi/overview"}]
+    ,
+...
+}
+```
+
+Please make sure to have your `datapackage.json` well structured to ease the understanding of your Data Package content. The [Online DataPackage.json Creator](http://data.okfn.org/tools/create) can help you create the general structure.  
+
+### Contributors and maintainers fields
+
+Add the 'contributors' and 'maintainers' fields if you wish to keep the credits for the package.
+
+----
+
+## 4) Data Package Folder Names and Structure
 
 It is standard practice to use the Data Package name (from the
 `datapackage.json`) for the name of the folder/directory in which the Data
@@ -62,10 +111,12 @@ Package is kept.
 
 If storing in e.g. git(hub) this would also be the the name of the repository.
 
+If you include scripts allowing to automate the data extraction process, these should be stored in a `script` folder/directory.
+
 ----
 
 
-## README
+## 5) README
 
 A README is a text file giving (human-readable) information about your dataset.
 
@@ -83,7 +134,7 @@ If markdown is used the file SHOULD be named `README.md` and otherwise SHOULD be
 ### Sections
 
 You can include anything you like in your README. It is standard practice to
-include some or all of the following sections.
+include some (if possible all) of the following sections: **Introduction, Data, Preparation, License**.
 
 We SHOULD NOT include the title of the Data Package at the top of the README.
 
@@ -95,33 +146,43 @@ following markdown in your README:
 ## Data
 ```
 
-#### Introduction
+#### **Introduction**
 
 Start with a short description of the dataset (the first sentence and first
 paragraph should be extractable to provide short standalone descriptions).
 
-Unlike other sections this section SHOULD NOT have a heading as it starts the README. (i.e. you do not
+Unlike other sections **this section SHOULD NOT have a heading** as it starts the README. (i.e. you do not
 need the heading `## Introduction` 
 
-#### Data
+#### **Data**
 
 Put specific information about the data in a Data section. This can be things
 like information about the source of the data, the specific structure of the
 data, missing values etc.
 
-#### Preparation
+#### **Preparation**
 
 Put information on preparing the data in a Preparation section. In particular,
 any instructions about how to run any preparation and processing scripts to
 generate the data should go here.
 
-#### License
+#### **License**
 
 Put additional information on the permissions and licensing of the data in the
 Data Package in the License section.
 
-### Examples
+Since licensing information is often not clear from the data producers, the guideline here is to license the Data Package under the Public Domain Dedication and License, and then to add any relevant information or disclaimers regarding the source data. 
 
-For examples of standard READMDS see the Core Datasets at
-http://data.okfn.org/data/
+See for example 
+* http://data.okfn.org/data/core/country-list#readme 
+* http://data.okfn.org/data/core/corruption-perceptions-index#readme
+
+See also the following thread https://discuss.okfn.org/t/copyright-on-data-sources/189.
+
+----
+
+## 6) Examples
+
+For examples of well-structured Data Package see:
+* http://data.okfn.org/data/core/corruption-perceptions-index
 


### PR DESCRIPTION
The FAQ page contains most of the conventions for publishing a Data Package, and I think it would be better to change its name to something more explicit like "Standards to follow".

I updated it with some recurrent corrections I ask when reviewing packages. These include mainly: The formatting of the README, the license, the formatting of the datapackage.json, and the addition of the contributors/maintainers fields.

Since I am a newbie here, I am not sure that all of these recommendations should be the best practices.

I see that most (if not all) packages so far do not follow strict guidelines. 

What is the policy, should we ensure best practices and a clear example of what an 'ideal' Data Package is, or first welcome any contribution that passes the validation and view test?

Any feedback welcome!



 

