### PR TITLE
Combine the catalog and core lists when fetching data packages

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -43,6 +43,14 @@ Catalog.prototype.query = function(q) {
 Catalog.prototype.loadUrl = function(mainListUrl, coreListUrl, cb) {
   var that = this;
   getDataPackageLists(mainListUrl, coreListUrl, function(err, dpUrls, coreUrls) {
+
+    // Ensure dpUrls contains all elements in coreUrls
+    coreUrls.forEach(function(url) {
+      if (dpUrls.indexOf(url) == -1) {
+        dpUrls.push(url);
+      }
+    });
+
     loadDataPackages(dpUrls, function(err, results) {
       if (err) {
         cb(err);


### PR DESCRIPTION
This allows the core list to contain items that aren't in the catalog
list, which is already the case. The registry has 35 URLs in the core
list, while only 33 of those are in the catalog, currently resulting in
the 2 remaining data packages not being displayed.