### PR TITLE
Update default data package list URLs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,5 @@
-var CATALOG_URL_DEFAULT = 'http://raw.github.com/datasets/registry/master/github-list.txt';
-var CORE_CATALOG_DEFAULT = 'http://raw.github.com/datasets/registry/master/datapackage-list.txt';
+var CATALOG_URL_DEFAULT = 'https://raw.github.com/datasets/registry/master/catalog-list.txt';
+var CORE_CATALOG_DEFAULT = 'https://raw.github.com/datasets/registry/master/core-list.txt';
 
 var config = {
   CATALOG_LIST: process.env.CATALOG_LIST || CATALOG_URL_DEFAULT,


### PR DESCRIPTION
Per datasets/registry@7e777947, github-list.txt became catalog-list.txt
and datapackage-list.txt was renamed to core-list.txt.