### PR TITLE
Mention Data Package golang support

### DIFF
--- a/views/tools/index.html
+++ b/views/tools/index.html
@@ -132,10 +132,10 @@ Tools and Plugins
     <h3>Data Validation</h3>
     <ul>
       <li>
-        <strong>Good Tables</strong> is both a library and online web service for validating tabular data against a JSON Table Schema. It is available as both a <a href="https://github.com/okfn/goodtables">Python library</a> and a 
+        <strong>Good Tables</strong> is both a library and online web service for validating tabular data against a JSON Table Schema. It is available as both a <a href="https://github.com/okfn/goodtables">Python library</a> and a
     <a href="http://goodtables.okfnlabs.org/">web service</a> for validating tabular data and getting actionable information to fix errors.
       </li>
-      <li> 
+      <li>
         <strong><a href="http://csvlint.io/">CSVLint</a></strong>
       </li>
     </ul>
@@ -143,11 +143,12 @@ Tools and Plugins
     <h3>Data Package Viewer</h3>
     <ul>
       <li>See the viewer linked at the top of this page</li>
-      <li>The ODI's <a href="http://git-viewer.labs.theodi.org/">Git Data Viewer</a> 
+      <li>The ODI's <a href="http://git-viewer.labs.theodi.org/">Git Data Viewer</a>
       can preview Data Packages stored in git repositories.
-      See also the <a href='http://theodi.org/blog/git-data-publishing'>blog post</a> and 
+      See also the <a href='http://theodi.org/blog/git-data-publishing'>blog post</a> and
       <a href='https://github.com/theodi/git-data-viewer'>source code</a>.
       </li>
+    </ul>
 
     <h3>JSON Schema Files</h3>
     <p>
@@ -158,6 +159,10 @@ Tools and Plugins
         <li><code>csv-dialect-description-format.json</code> -- for validating <a href="http://dataprotocols.org/csv-dialect/">CSV Dialect Description Format</a> <code>dialect</code> objects</li>
       </ul>
       Visit <a href="https://github.com/dataprotocols/schemas">dataprotocols/schemas</a> for more information.
+    </p>
+    <h3>Golang support</h3>
+    <p>
+      <a href="https://github.com/the42/datapackage">This Golang package</a> provides struct specifications for Data Package as well as a command line tool to create Data Packages.
     </p>
   </div>
 


### PR DESCRIPTION
Also add a `</ul>` tag as I thought it was missing and caused formatting glitches.

Other changes by editor auto-stripping eol blanks.