### PR TITLE
migrate express from 3.x to 4.x

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,8 @@
 var express = require('express')
+  , methodOverride = require('method-override')
+  , bodyParser = require('body-parser')
+  , logger = require('morgan')
+  , favicon = require('serve-favicon')
   , path = require('path')
   , nunjucks = require('nunjucks')
   , routes = require('./routes')
@@ -14,18 +18,17 @@ var CORSSupport = function(req, res, next) {
   next();
 }
 
-app.configure(function(){
-  app.set('port', process.env.PORT || 5000);
-  app.set('views', __dirname + '/views');
-  // app.set('view engine', 'html');
-  // app.engine('html', require('hbs').__express);
-  app.use(express.favicon());
-  app.use(express.logger('dev'));
-  app.use(express.bodyParser());
-  app.use(express.methodOverride());
-  app.use(CORSSupport);
-  app.use(express.static(path.join(__dirname, 'public')));
-});
+app.set('port', process.env.PORT || 5000);
+app.set('views', __dirname + '/views');
+// app.set('view engine', 'html');
+// app.engine('html', require('hbs').__express);
+// app.use(favicon(__dirname + '/public/favicon.ico'));
+app.use(logger('dev'));
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(methodOverride());
+app.use(CORSSupport);
+app.use(express.static(path.join(__dirname, 'public')));
 
 var env = new nunjucks.Environment(new nunjucks.FileSystemLoader('views'));
 env.express(app);

--- a/package.json
+++ b/package.json
@@ -1,32 +1,36 @@
 {
-    "name": "datahub"
-  , "version": "0.1.0"
-  , "author": "Open Knowledge Foundation <labs@okfn.org>"
-  , "repository": {
+  "name": "datahub",
+  "version": "0.1.0",
+  "author": "Open Knowledge Foundation <labs@okfn.org>",
+  "repository": {
     "type": "git",
     "url": "https://github.com/okfn/data.okfn.org"
-  }
-  , "license": "MIT"
-  , "dependencies": {
-      "express": "3.x",
-      "nunjucks": "0.1.8",
-      "request": "",
-      "marked": "",
-      "JSV": "",
-      "csv": "",
-      "csv-parse": "",
-      "stream-transform": "",
-      "underscore": "",
-      "datapackage": "0.3.0",
-      "datapackage-identifier": ">=0.3.1",
-      "datapackage-validate": ">=0.2.3",
-      "datapackage-read": ">=0.2.2"
-  }
-  , "devDependencies": {
+  },
+  "license": "MIT",
+  "dependencies": {
+    "JSV": "",
+    "body-parser": "^1.14.2",
+    "csv": "",
+    "csv-parse": "",
+    "datapackage": "0.3.0",
+    "datapackage-identifier": ">=0.3.1",
+    "datapackage-read": ">=0.2.2",
+    "datapackage-validate": ">=0.2.3",
+    "express": "4.x",
+    "marked": "",
+    "method-override": "^2.3.5",
+    "morgan": "^1.6.1",
+    "nunjucks": "0.1.8",
+    "request": "",
+    "serve-favicon": "^2.3.0",
+    "stream-transform": "",
+    "underscore": ""
+  },
+  "devDependencies": {
     "supertest": "",
     "mocha": ""
-  }
-  , "engines": {
+  },
+  "engines": {
     "node": "0.10.x",
     "npm": "1.3.x"
   }


### PR DESCRIPTION
while we are using data.okfn.org & core datasets source code, I've edited some code to migrate express from 3.x to 4.x.

merge it if you're interested in migration :)